### PR TITLE
Update tidytlg vignette per CRAN comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidytlg
 Title: Create TLGs using the 'tidyverse'
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
      c(person(given = "Nicholas",
            family = "Masel",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
+# tidytlg 0.1.1
+
+* Updated tidytlg.Rmd vignette to write to temp directory instead of user home directory
+
 # tidytlg 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.
-* Inital release of tidytlg
+* Initial release of tidytlg

--- a/vignettes/tidytlg.Rmd
+++ b/vignettes/tidytlg.Rmd
@@ -13,6 +13,8 @@ knitr::opts_chunk$set(
   comment = "#>",
   fig.path = "figures"
 )
+
+working_dir <- tempdir()
 ```
 
 ## Overview of TLG Programming
@@ -183,7 +185,7 @@ The `gentlg` function call below will create the rtf output using the `tblid` as
 tblid <- "Table01"
 
 gentlg(huxme       = tbl,
-       opath       = system.file("extdata", package = "tidytlg"), 
+       opath       = file.path(working_dir), 
        file        = tblid,
        orientation = "landscape",
        title_file = system.file("extdata/titles.xls", package = "tidytlg"))
@@ -302,7 +304,7 @@ plot <- ggplot(data = adsl, aes(x = HEIGHTBL, y = WEIGHTBL)) +
   facet_wrap(~SEX, nrow=1)
 
 # create png file
-png(file.path(system.file("extdata", package = "tidytlg"), paste0(tblid,".png")), width=2800, height=1300, res=300, type = "cairo")
+png(file.path(working_dir, paste0(tblid,".png")), width=2800, height=1300, res=300, type = "cairo")
 
 plot
 
@@ -315,7 +317,7 @@ gentlg(tlf = "g",
        plotwidth = 10,
        plotheight = 5,
        orientation = "landscape",
-       opath       = system.file("extdata", package = "tidytlg"), 
+       opath       = file.path(working_dir),, 
        file = tblid,
        title_file = system.file("extdata/titles.xls", package = "tidytlg"))
 ```


### PR DESCRIPTION
I got this CRAN comment this morning:
> Please correct before 2023-05-23 to safely retain your package on CRAN.

The check problems on the Debian systems are caused by attempts to write to the user library to which all packages get installed before checking (and which now is remounted read-only for checking).

Having package code which is run as part of the checks and attempts to write to the user library violates the CRAN Policy's

  Packages should not write in the user’s home filespace (including
  clipboards), nor anywhere else on the file system apart from the R
  session’s temporary directory (or during installation in the location
  pointed to by TMPDIR: and such usage should be cleaned up).


This PR updates this and bumps the version.