### PR TITLE
Update logic for wcol_check

### DIFF
--- a/R/check_args.R
+++ b/R/check_args.R
@@ -685,8 +685,7 @@ check_wcol <- function(huxme, wcol) {
     "anbr", "roworder", "boldme", "indentme", "newrows", "newpage",
     "rowvar", "row_type", "nested_level", "group_level"
   )
-  huxme_output <- huxme[- (which(names(huxme) %in% lst_to_remove))]
-  huxme_output <- huxme_output %>% dplyr::select(!c(any_of("func"),
+  huxme_output <- huxme %>% dplyr::select(!c(any_of(c("func", lst_to_remove)),
                                                     ends_with("_ord")))
 
   if (length(wcol) == 1 || length(wcol) == length(huxme_output)) {

--- a/tests/testthat/test-check_args.R
+++ b/tests/testthat/test-check_args.R
@@ -488,3 +488,13 @@ test_that("Test add_format", {
 
   expect_error(basefreq %>% dplyr::select(-row_type) %>% add_format(),"Reqiured fields anbr,  for function add_format")
 })
+
+test_that("Sparse dfs pass check_wcol works as expected with sparse dfs", {
+
+  a_freq <- freq(cdisc_adsl,
+                 rowvar = "ITTFL",
+                 colvar = "TRT01PN") %>%
+    select(-c("row_type", "group_level"))
+
+  expect_equal(check_wcol(a_freq, c(1,1,1,1)), NULL)
+})


### PR DESCRIPTION
Another simple update here. When there were no matches with columns to remove, it removed all the columns instead of none. This fixes that behavior.