### PR TITLE
fix: stopped rendering an empty footer

### DIFF
--- a/R/gentlg_single.R
+++ b/R/gentlg_single.R
@@ -27,7 +27,7 @@ gentlg_single <- function(huxme = NULL,
     function(x) arglist[[x]] <<- eval(rlang::sym(x))
   })
   check_gentlg(arglist)
-  if (is.na(footers) || length(footers) == 0) {
+  if (identical(footers, NA) || length(footers) == 0) {
     footers <- NULL
   }
 

--- a/R/gentlg_single.R
+++ b/R/gentlg_single.R
@@ -27,6 +27,9 @@ gentlg_single <- function(huxme = NULL,
     function(x) arglist[[x]] <<- eval(rlang::sym(x))
   })
   check_gentlg(arglist)
+  if (is.na(footers) || length(footers) == 0) {
+    footers <- NULL
+  }
 
   if (!is.null(title_file)) {
     title_df <- readxl::read_excel(title_file,

--- a/R/gentlg_single.R
+++ b/R/gentlg_single.R
@@ -749,7 +749,7 @@ gentlg_single <- function(huxme = NULL,
     if (dev.cur() == 1) {
       # If there is no graphics dev available. Create a NULL PDF device
       pdf(NULL)
-      filin <- round(
+      round(
         1440 / graphics::strwidth(
           expression(huxtable::bold(paste0(file, ":"))),
           family = "serif",
@@ -761,7 +761,7 @@ gentlg_single <- function(huxme = NULL,
       # Close the device
       dev.off()
     } else {
-      filin <- round(
+      round(
         1440 / graphics::strwidth(
           expression(huxtable::bold(paste0(file, ":"))),
           family = "serif",
@@ -771,8 +771,6 @@ gentlg_single <- function(huxme = NULL,
         0
       )
     }
-
-
 
     # Make repeated header on each page
     ht <- add_header(ht, paste0(

--- a/R/quick_rtf_jnj.R
+++ b/R/quick_rtf_jnj.R
@@ -504,7 +504,6 @@ custom_to_rtf <- function(ht, fc_tables = rtf_fc_tables(ht), watermark,
   tc <- huxtable::text_color(ht)
 
   ## MAKE CELLX DEFINITIONS ----
-
   left_merge <- ifelse(huxtable::colspan(ht) > 1, "\\clmgf", "")
   top_merge <- ifelse(huxtable::rowspan(ht) > 1, "\\clvmgf", "")
   dc <- display_cells(ht, all = TRUE)


### PR DESCRIPTION
* stopped rendering an empty row in cases where the footer passed to `gentlg` is of length 0 or NA

Closes #31

Test with the following code:
```
devtools::load_all('.')

final <- data.frame(
  label = c(
    "Overall", "Safety Analysis Set",
    "Any Adverse event{\\super a}", "- Serious Adverse Event"
  ),
  Drug_A = c("", "40", "10 (25%)", "0"),
  Drug_B = c("", "40", "10 (25%)", "0"),
  anbr = c(1, 2, 3, 4),
  roworder = c(1, 1, 1, 1),
  boldme = c(1, 0, 0, 0),
  newrows = c(0, 0, 1, 0),
  indentme = c(0, 0, 0, 1),
  newpage = c(0, 0, 0, 0)
)

# Produce output in rtf format

## footnote is blank
gentlg(
  huxme = final,
  wcol = c(0.70, 0.15, 0.15),
  file = "TSFAEX",
  title = "This is Amazing Demonstration 1",
  colheader = c(" ","Drug A","Drug B"),
  footers = ""
) # empty footer row

gentlg(
  huxme = final,
  wcol = c(0.70, 0.15, 0.15),
  file = "TSFAEX",
  title = "This is Amazing Demonstration 1",
  colheader = c(" ","Drug A","Drug B"),
  footers = NA
) # no footer row

## footenote is NA
gentlg(
  huxme = final,
  wcol = c(0.70, 0.15, 0.15),
  file = "TSFAEX",
  title = "This is Amazing Demonstration 1",
  colheader = c(" ","Drug A","Drug B"),
  footers = character(0)
) # no footer row

## footnote is NULL, and this is the correct output
gentlg(
  huxme = final,
  wcol = c(0.70, 0.15, 0.15),
  file = "TSFAEX",
  title = "This is Amazing Demonstration 1",
  colheader = c(" ","Drug A","Drug B"),
  footers = NULL
) # no footer row
```
