### PR TITLE
added argument `footers_one_row` in `gentlg()` and `gentlg_single()`,…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 - Exported functions `get_file_name()` and `insert_empty_rows()`.
 - Updated `gentlg_single()` to replace, in the first column of tables/listings headers, every leading whitespace with 90 twips (0.0625 inches) left-indentation RTF markup.
 - `gentlg()` argument `wcol` now allows for a list of column width vectors when `huxme` is a list of tables.
+- `gentlg()` new argument `footers_one_row` which allows to merge footers as a single table row (default = FALSE)
+
 
 # tidytlg 0.11.0
 

--- a/R/gentlg.R
+++ b/R/gentlg.R
@@ -94,6 +94,8 @@
 #' (Default = `list()`) Used to specify individual column or cell alignments.
 #' Each named list contains `row`, `col`, and `value`, which are passed to
 #' [huxtable::set_align()] to set the alignments.
+#' @param footers_one_row (optional) Logical. Whether to export the footers
+#' as a single table row (Default = `FALSE`).
 #'
 #' @section `Huxme` Details:
 #' For tables and listings, formatting of the output can be dictated through the
@@ -256,7 +258,8 @@ gentlg <- function(huxme = NULL,
                    pagenum = FALSE,
                    bottom_borders = "old_format",
                    border_fns = list(),
-                   alignments = list()) {
+                   alignments = list(),
+                   footers_one_row = FALSE) {
   # Validate `alignments` here because of its complicated data structure
   stopifnot("`alignments` must be a list" = is.list(alignments))
 
@@ -306,7 +309,8 @@ gentlg <- function(huxme = NULL,
       pagenum = pagenum,
       bottom_borders = bottom_borders,
       border_fns = border_fns,
-      alignments = alignments
+      alignments = alignments,
+      footers_one_row = footers_one_row
     )
 
     if (print.hux == FALSE) {
@@ -410,7 +414,8 @@ gentlg <- function(huxme = NULL,
         bottom_borders = bottom_borders,
         border_fns = border_fns,
         alignments = alignments,
-        index_in_result = index
+        index_in_result = index,
+        footers_one_row = footers_one_row
       )
     },
     ht = huxme,

--- a/R/gentlg_single.R
+++ b/R/gentlg_single.R
@@ -20,7 +20,8 @@ gentlg_single <- function(huxme = NULL,
                           bottom_borders = NULL,
                           border_fns = list(),
                           alignments = list(),
-                          index_in_result = 1) {
+                          index_in_result = 1,
+                          footers_one_row = FALSE) {
   assertthat::is.count(index_in_result)
   # check all the arguments being passed in except ...
   assertthat::assert_that(
@@ -934,6 +935,13 @@ gentlg_single <- function(huxme = NULL,
   }
 
   if (!is.null(footers)) {
+    if (isTRUE(footers_one_row)) {
+      if (is_format_rtf(format)) {
+        footers <- paste(footers, collapse = " \\line ")
+      } else {
+        footers <- paste(footers, collapse = " <br/> ")
+      }
+    }
     ht <- add_footer(ht, footers[1], first = TRUE)
 
     if (length(footers) > 1) {

--- a/R/gentlg_single.R
+++ b/R/gentlg_single.R
@@ -939,7 +939,7 @@ gentlg_single <- function(huxme = NULL,
       if (is_format_rtf(format)) {
         footers <- paste(footers, collapse = " \\line ")
       } else {
-        footers <- paste(footers, collapse = " <br/> ")
+        footers <- paste(footers, collapse = " <br /> ")
       }
     }
     ht <- add_footer(ht, footers[1], first = TRUE)

--- a/man/gentlg.Rd
+++ b/man/gentlg.Rd
@@ -26,7 +26,8 @@ gentlg(
   pagenum = FALSE,
   bottom_borders = "old_format",
   border_fns = list(),
-  alignments = list()
+  alignments = list(),
+  footers_one_row = FALSE
 )
 }
 \arguments{
@@ -139,6 +140,9 @@ the matrix passed to \code{bottom_borders}. Vectorized. See
 (Default = \code{list()}) Used to specify individual column or cell alignments.
 Each named list contains \code{row}, \code{col}, and \code{value}, which are passed to
 \code{\link[huxtable:align]{huxtable::set_align()}} to set the alignments.}
+
+\item{footers_one_row}{(optional) Logical. Whether to export the footers
+as a single table row (Default = \code{FALSE}).}
 }
 \value{
 A list of formatted \code{huxtables} with desired

--- a/tests/testthat/test-gentlg.R
+++ b/tests/testthat/test-gentlg.R
@@ -1,7 +1,6 @@
 df <- data.frame(label = c("boy", "girl"), name = c("Bob", "Lily"), age = c(12, 15))
 
 test_that("custom alignments work", {
-  df <- data.frame(label = c("boy", "girl"), name = c("Bob", "Lily"), age = c(12, 15))
 
   # `alignments` must be a list of named lists
   expect_error(gentlg(huxme = df, print.hux = FALSE, alignments = 1), "`alignments` must be a list")
@@ -141,4 +140,19 @@ test_that("gentlg() validates hux length equals wcol length if wcol is a list", 
   ),
   "Arguments \\'wcol\\' and \\'huxme\\' must have the same length."
   )
+})
+
+test_that("gentlg() saves footnotes as one row or multiple rows depending on 'footers_one_row'", {
+  footers <- c("Footer 1", "Footer 2", "Footer 3")
+  ht1 <- gentlg(huxme = df, print.hux = FALSE)[[1]]
+  ht2 <- gentlg(huxme = df, print.hux = FALSE, footers = footers)[[1]]
+  ht3 <- gentlg(huxme = df, print.hux = FALSE, footers = footers, footers_one_row = TRUE)[[1]]
+  # check the overal number of rows
+  expect_equal(nrow(ht2), nrow(ht1) + length(footers))
+  expect_equal(nrow(ht3), nrow(ht1) + 1)
+  # check the footers content
+  ht2_footers <- as.data.frame(ht2[5:7, 1])[, 1]
+  ht3_footers <- as.data.frame(ht3[5, 1])[, 1]
+  expect_equal(ht2_footers, c("\\line Footer 1", "Footer 2", "Footer 3"))
+  expect_equal(ht3_footers, "\\line Footer 1 \\line Footer 2 \\line Footer 3")
 })


### PR DESCRIPTION
… added unit tests

this PR adds optional argument `footers_one_row` to functions `gentlg()` and `gentlg_single()`

To ensure backwards compatibility, we set default value to FALSE, so outputs produced remain the same. If user calls `gentlg(..., footers_one_row = TRUE)`, then output RTF/HTML footers will belong to the same table row/cell (still preserving the breaklines).